### PR TITLE
Refactor Crypt

### DIFF
--- a/Baked Potatoes/Hash.cpp
+++ b/Baked Potatoes/Hash.cpp
@@ -66,7 +66,7 @@ namespace bpl
 				}
 			}
 
-			std::string SHA1Context::Hash()
+			std::string SHA1Context::Hash(bool ReturnHex)
 			{
 				Context->Buffer.first[Context->Buffer.second++] = 0x80;
 				
@@ -89,14 +89,14 @@ namespace bpl
 
 				Reset();
 
-				return bpl::utility::ToHex(Digest);
+				return ReturnHex ? bpl::utility::ToHex(Digest) : Digest;
 			}
 
-			std::string SHA1Context::Hash(const void* Message, std::size_t Length)
+			std::string SHA1Context::Hash(const void* Message, std::size_t Length, bool ReturnHex)
 			{
 				Update(Message, Length);
 
-				return Hash();
+				return Hash(ReturnHex);
 			}
 
 			void SHA1Context::HashBuffer()
@@ -174,9 +174,9 @@ namespace bpl
 				Update(Message.c_str(), Message.length());
 			}
 
-			std::string SHA1Context::Hash(const std::string& Message)
+			std::string SHA1Context::Hash(const std::string& Message, bool ReturnHex)
 			{
-				return Hash(Message.c_str(), Message.length());
+				return Hash(Message.c_str(), Message.length(), ReturnHex);
 			}
 
 			const std::size_t SHA1Context::BlockSize() const

--- a/Baked Potatoes/Hash.hpp
+++ b/Baked Potatoes/Hash.hpp
@@ -29,9 +29,9 @@ namespace bpl
 				virtual void Update(const void* Message, std::size_t Length) = 0;
 				virtual void Update(const std::string& Message) = 0;
 
-				virtual std::string Hash() = 0;
-				virtual std::string Hash(const void* Message, std::size_t Length) = 0;
-				virtual std::string Hash(const std::string& Message) = 0;
+				virtual std::string Hash(bool ReturnHex = true) = 0;
+				virtual std::string Hash(const void* Message, std::size_t Length, bool ReturnHex = true) = 0;
+				virtual std::string Hash(const std::string& Message, bool ReturnHex = true) = 0;
 
 				virtual const std::size_t BlockSize() const = 0; // In Bytes
 				virtual const std::size_t DigestSize() const = 0; // In Bits
@@ -72,9 +72,9 @@ namespace bpl
 				void Update(const void* Message, std::size_t Length) override;
 				void Update(const std::string& Message) override;
 
-				std::string Hash() override;
-				std::string Hash(const void* Message, std::size_t Length) override;
-				std::string Hash(const std::string& Message) override;
+				std::string Hash(bool ReturnHex = true) override;
+				std::string Hash(const void* Message, std::size_t Length, bool ReturnHex = true) override;
+				std::string Hash(const std::string& Message, bool ReturnHex = true) override;
 
 				const std::size_t BlockSize() const override; // In Bytes
 				const std::size_t DigestSize() const override; // In Bits

--- a/Baked Potatoes/Hash.hpp
+++ b/Baked Potatoes/Hash.hpp
@@ -4,6 +4,7 @@
 #include <list>
 #include <memory>
 #include <tuple>
+#include "Utility.hpp"
 
 #ifdef UNIT_TESTING // Used for Unit Testing
 namespace LibraryTests
@@ -18,7 +19,25 @@ namespace bpl
 	{
 		namespace hash
 		{
-			class SHA1Context
+			class HashInterface : public bpl::utility::Uncopyable
+			{
+			public:
+				virtual ~HashInterface() = default;
+
+				virtual void Reset() = 0;
+
+				virtual void Update(const void* Message, std::size_t Length) = 0;
+				virtual void Update(const std::string& Message) = 0;
+
+				virtual std::string Hash() = 0;
+				virtual std::string Hash(const void* Message, std::size_t Length) = 0;
+				virtual std::string Hash(const std::string& Message) = 0;
+
+				virtual const std::size_t BlockSize() const = 0; // In Bytes
+				virtual const std::size_t DigestSize() const = 0; // In Bits
+			};
+
+			class SHA1Context : public HashInterface
 			{
 #ifdef UNIT_TESTING // Give the Test Class access
 				friend class ::LibraryTests::SHA1Test;
@@ -45,26 +64,20 @@ namespace bpl
 			public:
 				SHA1Context();
 
-				SHA1Context(const SHA1Context&) = delete;
-				SHA1Context operator=(const SHA1Context&) = delete;
-
 				SHA1Context(SHA1Context&&);
 				SHA1Context& operator=(SHA1Context&&);
 
-				void Reset();
+				void Reset() override;
 
-				void Update(const void* Message, std::size_t Length);
-				void Update(const std::string& Message);
+				void Update(const void* Message, std::size_t Length) override;
+				void Update(const std::string& Message) override;
 
-				std::array<uint8_t, 20> Hash();
-				std::array<uint8_t, 20> Hash(const void* Message, std::size_t Length);
-				std::array<uint8_t, 20> Hash(const std::string& Message);
+				std::string Hash() override;
+				std::string Hash(const void* Message, std::size_t Length) override;
+				std::string Hash(const std::string& Message) override;
 
-				// In Bytes
-				static const std::size_t BlockSize = 64;
-
-				// In Bits
-				static const std::size_t DigestSize = 160;
+				const std::size_t BlockSize() const override; // In Bytes
+				const std::size_t DigestSize() const override; // In Bits
 			};
 		}
 	}

--- a/Baked Potatoes/Utility.cpp
+++ b/Baked Potatoes/Utility.cpp
@@ -12,50 +12,32 @@ namespace bpl
 
 		uint64_t BigEndian64(uint64_t Value)
 		{
-			if (Endianness())
-				return _byteswap_uint64(Value);
-			else
-				return Value;
+			return Endianness() ? _byteswap_uint64(Value) : Value;
 		}
 
 		uint32_t BigEndian32(uint32_t Value)
 		{
-			if (Endianness())
-				return _byteswap_ulong(Value);
-			else
-				return Value;
+			return Endianness() ? _byteswap_ulong(Value) : Value;
 		}
 
 		uint16_t BigEndian16(uint16_t Value)
 		{
-			if (Endianness())
-				return _byteswap_ushort(Value);
-			else
-				return Value;
+			return Endianness() ? _byteswap_ushort(Value) : Value;
 		}
 
 		uint64_t LittleEndian64(uint64_t Value)
 		{
-			if (!Endianness())
-				return _byteswap_uint64(Value);
-			else
-				return Value;
+			return !Endianness() ? _byteswap_uint64(Value) : Value;
 		}
 
 		uint32_t LittleEndian32(uint32_t Value)
 		{
-			if (!Endianness())
-				return _byteswap_ulong(Value);
-			else
-				return Value;
+			return !Endianness() ? _byteswap_ulong(Value) : Value;
 		}
 
 		uint16_t LittleEndian16(uint16_t Value)
 		{
-			if (!Endianness())
-				return _byteswap_ushort(Value);
-			else
-				return Value;
+			return !Endianness() ? _byteswap_ushort(Value) : Value;
 		}
 	}
 }

--- a/Baked Potatoes/Utility.cpp
+++ b/Baked Potatoes/Utility.cpp
@@ -39,5 +39,21 @@ namespace bpl
 		{
 			return !Endianness() ? _byteswap_ushort(Value) : Value;
 		}
+
+		std::string ToHex(const std::string& Array)
+		{
+			const std::string LookUpTable = "0123456789abcdef";
+			std::string Result;
+			Result.reserve(Array.length() * 2);
+
+			for (auto Character : Array)
+			{
+				auto Byte = static_cast<std::uint8_t>(Character);
+				Result.push_back(LookUpTable[Byte >> 4]);
+				Result.push_back(LookUpTable[Byte & 0xf]);
+			}
+
+			return Result;
+		}
 	}
 }

--- a/Baked Potatoes/Utility.cpp
+++ b/Baked Potatoes/Utility.cpp
@@ -46,9 +46,8 @@ namespace bpl
 			std::string Result;
 			Result.reserve(Array.length() * 2);
 
-			for (auto Character : Array)
+			for (uint8_t Byte : Array)
 			{
-				auto Byte = static_cast<std::uint8_t>(Character);
 				Result.push_back(LookUpTable[Byte >> 4]);
 				Result.push_back(LookUpTable[Byte & 0xf]);
 			}

--- a/Baked Potatoes/Utility.cpp
+++ b/Baked Potatoes/Utility.cpp
@@ -14,36 +14,48 @@ namespace bpl
 		{
 			if (Endianness())
 				return _byteswap_uint64(Value);
+			else
+				return Value;
 		}
 
 		uint32_t BigEndian32(uint32_t Value)
 		{
 			if (Endianness())
 				return _byteswap_ulong(Value);
+			else
+				return Value;
 		}
 
 		uint16_t BigEndian16(uint16_t Value)
 		{
 			if (Endianness())
 				return _byteswap_ushort(Value);
+			else
+				return Value;
 		}
 
 		uint64_t LittleEndian64(uint64_t Value)
 		{
 			if (!Endianness())
 				return _byteswap_uint64(Value);
+			else
+				return Value;
 		}
 
 		uint32_t LittleEndian32(uint32_t Value)
 		{
 			if (!Endianness())
 				return _byteswap_ulong(Value);
+			else
+				return Value;
 		}
 
 		uint16_t LittleEndian16(uint16_t Value)
 		{
 			if (!Endianness())
 				return _byteswap_ushort(Value);
+			else
+				return Value;
 		}
 	}
 }

--- a/Baked Potatoes/Utility.hpp
+++ b/Baked Potatoes/Utility.hpp
@@ -105,5 +105,18 @@ namespace bpl
 		uint32_t LittleEndian32(uint32_t Value);
 
 		uint16_t LittleEndian16(uint16_t Value);
+
+		struct Uncopyable
+		{
+		protected:
+			Uncopyable() = default;
+			~Uncopyable() = default;
+
+			Uncopyable(Uncopyable&&);
+			const Uncopyable& operator=(Uncopyable&&);
+
+			Uncopyable(const Uncopyable&) = delete;
+			const Uncopyable& operator=(const Uncopyable&) = delete;
+		};
 	}
 }

--- a/Baked Potatoes/Utility.hpp
+++ b/Baked Potatoes/Utility.hpp
@@ -36,63 +36,7 @@ namespace bpl
 			return (Value >> Shift) | (Value << (sizeof(Value) * 8 - Shift));
 		}
 
-		template <class Type, std::size_t Length>
-		std::string ByteToByteString(const std::array<Type, Length>& Input)
-		{
-			static_assert(std::is_integral<Type>::value, "Type must be integral");
-
-			std::array<uint8_t, Length * sizeof(Type)> Bytes;
-
-			for (std::size_t i = 0; i < Length; ++i)
-			{
-				for (std::size_t j = 0; j < sizeof(Type); ++j)
-					Bytes[i * sizeof(Type) + j] = static_cast<uint8_t>(static_cast<std::make_unsigned<Type>::type>(Input[i]) >> (sizeof(Type) - 1 - j) * 8);
-			}
-
-			std::stringstream Stream;
-
-			for (uint8_t i : Bytes)
-				Stream << std::setfill('0') << std::setw(2) << std::hex << i;
-
-			return Stream.str();
-		}
-
-		template <std::size_t Length>
-		std::string ByteToByteString(const std::array<uint8_t, Length>& Input)
-		{
-			std::stringstream Stream;
-
-			for (uint8_t i : Input)
-				Stream << std::setfill('0') << std::setw(1) << std::hex << i;
-
-			std::string Output = Stream.str();
-			return Output;
-		}
-
-		template <class Type, std::size_t Length>
-		std::string ByteToHexString(const std::array<Type, Length>& Input)
-		{
-			static_assert(std::is_integral<Type>::value, "Type must be integral");
-
-			std::stringstream Stream;
-			Stream << std::setfill('0') << std::setw(2 * sizeof(Type));
-
-			for (Type i : Input)
-				Stream << std::hex << std::setfill('0') << std::setw(2 * sizeof(Type)) << i;
-
-			return Stream.str();
-		}
-
-		template <std::size_t Length>
-		std::string ByteToHexString(const std::array<uint8_t, Length>& Input)
-		{
-			std::stringstream Stream;
-
-			for (auto i : Input)
-				Stream << std::setfill('0') << std::setw(2) << std::hex << static_cast<unsigned>(i);
-
-			return Stream.str();
-		}
+		std::string ToHex(const std::string& Array);
 
 		uint64_t BigEndian64(uint64_t Value);
 

--- a/Library Tests/Hash.Test.cpp
+++ b/Library Tests/Hash.Test.cpp
@@ -31,9 +31,9 @@ namespace LibraryTests
 			std::string Test2 = "Test vector from febooti.com";
 			std::string Test3 = "";
 
-			Assert::AreEqual("2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", ToHex(SHA1.Hash(Test1.c_str(), Test1.length())).c_str());
-			Assert::AreEqual("a7631795f6d59cd6d14ebd0058a6394a4b93d868", ToHex(SHA1.Hash(Test2.c_str(), Test2.length())).c_str());
-			Assert::AreEqual("da39a3ee5e6b4b0d3255bfef95601890afd80709", ToHex(SHA1.Hash(Test3.c_str(), Test3.length())).c_str());
+			Assert::AreEqual("2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", SHA1.Hash(Test1.c_str(), Test1.length()).c_str());
+			Assert::AreEqual("a7631795f6d59cd6d14ebd0058a6394a4b93d868", SHA1.Hash(Test2.c_str(), Test2.length()).c_str());
+			Assert::AreEqual("da39a3ee5e6b4b0d3255bfef95601890afd80709", SHA1.Hash(Test3.c_str(), Test3.length()).c_str());
 		}
 
 		TEST_METHOD(ContextResetsOnHash)
@@ -71,9 +71,9 @@ namespace LibraryTests
 			std::string Test2 = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
 			std::string Test3(1000000, 'a');
 
-			Assert::AreEqual("a9993e364706816aba3e25717850c26c9cd0d89d", ToHex(SHA1.Hash(Test1.c_str(), Test1.length())).c_str());
-			Assert::AreEqual("84983e441c3bd26ebaae4aa1f95129e5e54670f1", ToHex(SHA1.Hash(Test2.c_str(), Test2.length())).c_str());
-			Assert::AreEqual("34aa973cd4c4daa4f61eeb2bdbad27316534016f", ToHex(SHA1.Hash(Test3.c_str(), Test3.length())).c_str());
+			Assert::AreEqual("a9993e364706816aba3e25717850c26c9cd0d89d", SHA1.Hash(Test1.c_str(), Test1.length()).c_str());
+			Assert::AreEqual("84983e441c3bd26ebaae4aa1f95129e5e54670f1", SHA1.Hash(Test2.c_str(), Test2.length()).c_str());
+			Assert::AreEqual("34aa973cd4c4daa4f61eeb2bdbad27316534016f", SHA1.Hash(Test3.c_str(), Test3.length()).c_str());
 		}
 	};
 }

--- a/Library Tests/MAC.Test.cpp
+++ b/Library Tests/MAC.Test.cpp
@@ -39,7 +39,7 @@ namespace LibraryTests
 
 			auto Result = HMAC(Key, Message);
 
-			Assert::AreEqual(Expected.c_str(), bpl::utility::ByteToHexString(Result).c_str());
+			Assert::AreEqual(Expected.c_str(), Result.c_str());
 		}
 
 		TEST_METHOD(StringKey)
@@ -48,7 +48,7 @@ namespace LibraryTests
 			std::string Key = "My Very Secret Password";
 			std::string Expected = "ebdc867835d067237b2f384f5eded735a220246b";
 
-			Assert::AreEqual(Expected.c_str(), bpl::utility::ByteToHexString(HMAC(Key, Message)).c_str());
+			Assert::AreEqual(Expected.c_str(), HMAC(Key, Message).c_str());
 		}
 
 		TEST_METHOD(RFC2202)
@@ -58,39 +58,39 @@ namespace LibraryTests
 			std::string Message1 = "Hi There";
 			std::string Key1(20, 0x0b);
 			
-			Assert::AreEqual("b617318655057264e28bc0b6fb378c8ef146be00", bpl::utility::ByteToHexString(HMAC(Key1, Message1)).c_str());
+			Assert::AreEqual("b617318655057264e28bc0b6fb378c8ef146be00", HMAC(Key1, Message1).c_str());
 
 			std::string Message2 = "what do ya want for nothing?";
 			std::string Key2 = "Jefe";
 
-			Assert::AreEqual("effcdf6ae5eb2fa2d27416d5f184df9c259a7c79", bpl::utility::ByteToHexString(HMAC(Key2, Message2)).c_str());
+			Assert::AreEqual("effcdf6ae5eb2fa2d27416d5f184df9c259a7c79",HMAC(Key2, Message2).c_str());
 
 			std::string Message3(50, 0xdd);
 			std::string Key3(20, 0xaa);
 
-			Assert::AreEqual("125d7342b9ac11cd91a39af48aa17b4f63f175d3", bpl::utility::ByteToHexString(HMAC(Key3, Message3)).c_str());
+			Assert::AreEqual("125d7342b9ac11cd91a39af48aa17b4f63f175d3", HMAC(Key3, Message3).c_str());
 
 			std::string Message4(50, 0xcd);
 			std::string Key4;
 			Key4.resize(25);
 			std::iota(Key4.begin(), Key4.end(), 1);
 
-			Assert::AreEqual("4c9007f4026250c6bc8414f9bf50c86c2d7235da", bpl::utility::ByteToHexString(HMAC(Key4, Message4)).c_str());
+			Assert::AreEqual("4c9007f4026250c6bc8414f9bf50c86c2d7235da", HMAC(Key4, Message4).c_str());
 
 			std::string Message5 = "Test With Truncation";
 			std::string Key5(20, 0x0c);
 
-			Assert::AreEqual("4c1a03424b55e07fe7f27be1d58bb9324a9a5a04", bpl::utility::ByteToHexString(HMAC(Key5, Message5)).c_str());
+			Assert::AreEqual("4c1a03424b55e07fe7f27be1d58bb9324a9a5a04", HMAC(Key5, Message5).c_str());
 
 			std::string Message6 = "Test Using Larger Than Block-Size Key - Hash Key First";
 			std::string Key6(80, 0xaa);
 
-			Assert::AreEqual("aa4ae5e15272d00e95705637ce8a3b55ed402112", bpl::utility::ByteToHexString(HMAC(Key6, Message6)).c_str());
+			Assert::AreEqual("aa4ae5e15272d00e95705637ce8a3b55ed402112", HMAC(Key6, Message6).c_str());
 
 			std::string Message7 = "Test Using Larger Than Block-Size Key and Larger Than One Block-Size Data";
 			std::string Key7(80, 0xaa);
 
-			Assert::AreEqual("e8e99d0f45237d786d6bbaa7965c7808bbff1a91", bpl::utility::ByteToHexString(HMAC(Key7, Message7)).c_str());
+			Assert::AreEqual("e8e99d0f45237d786d6bbaa7965c7808bbff1a91", HMAC(Key7, Message7).c_str());
 		}
 	};
 }

--- a/Library Tests/Utility.Test.cpp
+++ b/Library Tests/Utility.Test.cpp
@@ -1,6 +1,8 @@
 #include "targetver.h"
 #include "CppUnitTest.h"
 #include "Utility.hpp"
+#include <cstdint>
+#include <numeric>
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
@@ -41,6 +43,52 @@ namespace LibraryTests
 		{
 			// System dependent
 			Assert::IsTrue(bpl::utility::Endianness());
+		}
+
+		TEST_METHOD(BigEndianConversions)
+		{
+			std::array<uint8_t, 8> Byte;
+			std::iota(Byte.begin(), Byte.end(), 0);
+			std::array<uint8_t, 8> Uint64ExpectedByte;
+			std::iota(Uint64ExpectedByte.rbegin(), Uint64ExpectedByte.rend(), 0);
+			std::array<uint8_t, 4> Uint32ExpectedByte;
+			std::iota(Uint32ExpectedByte.rbegin(), Uint32ExpectedByte.rend(), 0);
+			std::array<uint8_t, 2> Uint16ExpectedByte;
+			std::iota(Uint16ExpectedByte.rbegin(), Uint16ExpectedByte.rend(), 0);
+
+			std::uint64_t* Uint64 = reinterpret_cast<std::uint64_t*>(Byte.data());
+			std::uint64_t* Uint64Expected = reinterpret_cast<std::uint64_t*>(Uint64ExpectedByte.data());
+			std::uint32_t* Uint32 = reinterpret_cast<std::uint32_t*>(Byte.data());
+			std::uint32_t* Uint32Expected = reinterpret_cast<std::uint32_t*>(Uint32ExpectedByte.data());
+			std::uint16_t* Uint16 = reinterpret_cast<std::uint16_t*>(Byte.data());
+			std::uint16_t* Uint16Expected = reinterpret_cast<std::uint16_t*>(Uint16ExpectedByte.data());
+
+			Assert::AreEqual(*Uint64Expected, bpl::utility::BigEndian64(*Uint64));
+			Assert::AreEqual(*Uint32Expected, bpl::utility::BigEndian32(*Uint32));
+			Assert::AreEqual(*Uint16Expected, bpl::utility::BigEndian16(*Uint16));
+		}
+
+		TEST_METHOD(LittleEndianConversions)
+		{
+			std::array<uint8_t, 8> Byte;
+			std::iota(Byte.begin(), Byte.end(), 0);
+			std::array<uint8_t, 8> Uint64ExpectedByte;
+			std::iota(Uint64ExpectedByte.begin(), Uint64ExpectedByte.end(), 0);
+			std::array<uint8_t, 4> Uint32ExpectedByte;
+			std::iota(Uint32ExpectedByte.begin(), Uint32ExpectedByte.end(), 0);
+			std::array<uint8_t, 2> Uint16ExpectedByte;
+			std::iota(Uint16ExpectedByte.begin(), Uint16ExpectedByte.end(), 0);
+
+			std::uint64_t* Uint64 = reinterpret_cast<std::uint64_t*>(Byte.data());
+			std::uint64_t* Uint64Expected = reinterpret_cast<std::uint64_t*>(Uint64ExpectedByte.data());
+			std::uint32_t* Uint32 = reinterpret_cast<std::uint32_t*>(Byte.data());
+			std::uint32_t* Uint32Expected = reinterpret_cast<std::uint32_t*>(Uint32ExpectedByte.data());
+			std::uint16_t* Uint16 = reinterpret_cast<std::uint16_t*>(Byte.data());
+			std::uint16_t* Uint16Expected = reinterpret_cast<std::uint16_t*>(Uint16ExpectedByte.data());
+
+			Assert::AreEqual(*Uint64Expected, bpl::utility::LittleEndian64(*Uint64));
+			Assert::AreEqual(*Uint32Expected, bpl::utility::LittleEndian32(*Uint32));
+			Assert::AreEqual(*Uint16Expected, bpl::utility::LittleEndian16(*Uint16));
 		}
 
 		TEST_METHOD(RolTest)


### PR DESCRIPTION
In summary:
* Hash
 - New abstract base class `HashInterface`
 - `SHA1Context` returns an `std::string`
 - `BlockSize` & `DigestSize` are now functions
 - `ReturnHex` argument
   - If `true`: returns the digest as a hex string
    - If `false`: returns the actual digest
* HMAC
 - Returns an `std::string`
 - Exports the `Hash` template argument as `HashFunction`
* Utility
 - Add `Uncopyable` base class
 - Add `ToHex` String to Hex conversion
 - Remove unused functions